### PR TITLE
Ported package and examples to Elm 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
         "Collision2D"
     ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.19.0"
 }

--- a/examples/Circles.elm
+++ b/examples/Circles.elm
@@ -1,14 +1,50 @@
 import Color
-import Graphics.Collage as Collage
-import Graphics.Element as Element
+import Collage
+import Element
 import Mouse
-import Window
 import Collision2D
+import Window exposing (Size)
+import Html exposing (..)
+import Task
 
 
-main : Signal Element.Element
-main =
-  Signal.map2 scene Mouse.position Window.dimensions
+type alias Model =
+ { x : Int
+ , y : Int
+ , size: Size
+ }
+
+
+initialModel: Model
+initialModel =
+  { x = 0
+  , y = 0
+  , size = Size 0 0
+  }
+
+
+init : (Model, Cmd Msg)
+init =
+  (initialModel, Task.perform Resize Window.size)
+
+type Msg
+  = Position Int Int
+  | Resize Size
+
+
+update: Msg -> Model -> Model
+update msg model =
+  case msg of
+    Position x y ->
+        { model | x = x, y = y }
+    Resize size ->
+        { model | size = size }
+
+
+view: Model -> Html a
+view model =
+  Element.toHtml <|
+      scene (model.x, model.y) (model.size.width, model.size.height)
 
 
 scene : (Int,Int) -> (Int,Int) -> Element.Element
@@ -48,3 +84,16 @@ message title stringable =
   |> Element.show
   |> Collage.toForm
   |> Collage.move (0, 80)
+
+
+main =
+  Html.program
+    { init = init
+    , update = \msg m -> update msg m ! []
+    , view = view
+    , subscriptions =
+      (\_ -> Sub.batch
+        [ Window.resizes Resize
+        , Mouse.moves (\{x, y} -> Position x y)
+        ])
+    }

--- a/examples/RectangleSide.elm
+++ b/examples/RectangleSide.elm
@@ -1,14 +1,50 @@
 import Color
-import Graphics.Collage as Collage
-import Graphics.Element as Element
+import Collage
+import Element
 import Mouse
-import Window
 import Collision2D
+import Window exposing (Size)
+import Html exposing (..)
+import Task
 
 
-main : Signal Element.Element
-main =
-  Signal.map2 scene Mouse.position Window.dimensions
+type alias Model =
+ { x : Int
+ , y : Int
+ , size: Size
+ }
+
+
+initialModel: Model
+initialModel =
+  { x = 0
+  , y = 0
+  , size = Size 0 0
+  }
+
+
+init : (Model, Cmd Msg)
+init =
+  (initialModel, Task.perform Resize Window.size)
+
+type Msg
+  = Position Int Int
+  | Resize Size
+
+
+update: Msg -> Model -> Model
+update msg model =
+  case msg of
+    Position x y ->
+        { model | x = x, y = y }
+    Resize size ->
+        { model | size = size }
+
+
+view: Model -> Html a
+view model =
+  Element.toHtml <|
+      scene (model.x, model.y) (model.size.width, model.size.height)
 
 
 scene : (Int,Int) -> (Int,Int) -> Element.Element
@@ -48,3 +84,16 @@ message title stringable =
   title ++ ": " ++ (toString stringable)
   |> Element.show
   |> Collage.toForm
+
+
+main =
+  Html.program
+    { init = init
+    , update = \msg m -> update msg m ! []
+    , view = view
+    , subscriptions =
+      (\_ -> Sub.batch
+        [ Window.resizes Resize
+        , Mouse.moves (\{x, y} -> Position x y)
+        ])
+    }

--- a/examples/Rectangles.elm
+++ b/examples/Rectangles.elm
@@ -1,14 +1,50 @@
 import Color
-import Graphics.Collage as Collage
-import Graphics.Element as Element
+import Collage
+import Element
 import Mouse
-import Window
 import Collision2D
+import Window exposing (Size)
+import Html exposing (..)
+import Task
 
 
-main : Signal Element.Element
-main =
-  Signal.map2 scene Mouse.position Window.dimensions
+type alias Model =
+ { x : Int
+ , y : Int
+ , size: Size
+ }
+
+
+initialModel: Model
+initialModel =
+  { x = 0
+  , y = 0
+  , size = Size 0 0
+  }
+
+
+init : (Model, Cmd Msg)
+init =
+  (initialModel, Task.perform Resize Window.size)
+
+type Msg
+  = Position Int Int
+  | Resize Size
+
+
+update: Msg -> Model -> Model
+update msg model =
+  case msg of
+    Position x y ->
+        { model | x = x, y = y }
+    Resize size ->
+        { model | size = size }
+
+
+view: Model -> Html a
+view model =
+  Element.toHtml <|
+      scene (model.x, model.y) (model.size.width, model.size.height)
 
 
 scene : (Int,Int) -> (Int,Int) -> Element.Element
@@ -48,3 +84,16 @@ message title stringable =
   |> Element.show
   |> Collage.toForm
   |> Collage.move (0, 80)
+
+
+main =
+  Html.program
+    { init = init
+    , update = \msg m -> update msg m ! []
+    , view = view
+    , subscriptions =
+      (\_ -> Sub.batch
+        [ Window.resizes Resize
+        , Mouse.moves (\{x, y} -> Position x y)
+        ])
+    }

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -9,7 +9,11 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/mouse": "1.0.1 <= v < 2.0.0",
+        "elm-lang/window": "1.0.1 <= v < 2.0.0",
+        "evancz/elm-graphics": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.19.0"
 }

--- a/src/Collision2D.elm
+++ b/src/Collision2D.elm
@@ -1,4 +1,4 @@
-module Collision2D
+module Collision2D exposing
   ( axisAlignedBoundingBox
   , circleToCircle
   , Side(Top, Right, Bottom, Left)
@@ -7,7 +7,7 @@ module Collision2D
   , rectangle
   , Circle
   , circle
-  ) where
+  )
 
 {-| Detect collision/intersection of geometry in a defined 2D coordinate space
 AKA tell me when objects are touching or overlapping.


### PR DESCRIPTION
Porting the package to 0.18 was trivial. The less trivial part was to rewrite examples using TEA instead of signals. I didn't change package version since you might want to tweak something else by yourself. Thank you.